### PR TITLE
Fixed issue with include paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,50 +15,50 @@ set( INC_DIR "include" )
 
 set(
 	SOURCES
-	${INC_DIR}/libnoise/basictypes.h
-	${INC_DIR}/libnoise/exception.h
-	${INC_DIR}/libnoise/interp.h
-	${INC_DIR}/libnoise/latlon.h
-	${INC_DIR}/libnoise/mathconsts.h
-	${INC_DIR}/libnoise/misc.h
-	${INC_DIR}/libnoise/noise.h
-	${INC_DIR}/libnoise/noisegen.h
-	${INC_DIR}/libnoise/vectortable.h
-	${INC_DIR}/libnoise/model/cylinder.h
-	${INC_DIR}/libnoise/model/line.h
-	${INC_DIR}/libnoise/model/model.h
-	${INC_DIR}/libnoise/model/plane.h
-	${INC_DIR}/libnoise/model/sphere.h
-	${INC_DIR}/libnoise/module/abs.h
-	${INC_DIR}/libnoise/module/add.h
-	${INC_DIR}/libnoise/module/billow.h
-	${INC_DIR}/libnoise/module/blend.h
-	${INC_DIR}/libnoise/module/cache.h
-	${INC_DIR}/libnoise/module/checkerboard.h
-	${INC_DIR}/libnoise/module/clamp.h
-	${INC_DIR}/libnoise/module/const.h
-	${INC_DIR}/libnoise/module/curve.h
-	${INC_DIR}/libnoise/module/cylinders.h
-	${INC_DIR}/libnoise/module/displace.h
-	${INC_DIR}/libnoise/module/exponent.h
-	${INC_DIR}/libnoise/module/invert.h
-	${INC_DIR}/libnoise/module/max.h
-	${INC_DIR}/libnoise/module/min.h
-	${INC_DIR}/libnoise/module/module.h
-	${INC_DIR}/libnoise/module/modulebase.h
-	${INC_DIR}/libnoise/module/multiply.h
-	${INC_DIR}/libnoise/module/perlin.h
-	${INC_DIR}/libnoise/module/power.h
-	${INC_DIR}/libnoise/module/ridgedmulti.h
-	${INC_DIR}/libnoise/module/rotatepoint.h
-	${INC_DIR}/libnoise/module/scalebias.h
-	${INC_DIR}/libnoise/module/scalepoint.h
-	${INC_DIR}/libnoise/module/select.h
-	${INC_DIR}/libnoise/module/spheres.h
-	${INC_DIR}/libnoise/module/terrace.h
-	${INC_DIR}/libnoise/module/translatepoint.h
-	${INC_DIR}/libnoise/module/turbulence.h
-	${INC_DIR}/libnoise/module/voronoi.h
+	${INC_DIR}/${PROJECT_NAME}/basictypes.h
+	${INC_DIR}/${PROJECT_NAME}/exception.h
+	${INC_DIR}/${PROJECT_NAME}/interp.h
+	${INC_DIR}/${PROJECT_NAME}/latlon.h
+	${INC_DIR}/${PROJECT_NAME}/mathconsts.h
+	${INC_DIR}/${PROJECT_NAME}/misc.h
+	${INC_DIR}/${PROJECT_NAME}/noise.h
+	${INC_DIR}/${PROJECT_NAME}/noisegen.h
+	${INC_DIR}/${PROJECT_NAME}/vectortable.h
+	${INC_DIR}/${PROJECT_NAME}/model/cylinder.h
+	${INC_DIR}/${PROJECT_NAME}/model/line.h
+	${INC_DIR}/${PROJECT_NAME}/model/model.h
+	${INC_DIR}/${PROJECT_NAME}/model/plane.h
+	${INC_DIR}/${PROJECT_NAME}/model/sphere.h
+	${INC_DIR}/${PROJECT_NAME}/module/abs.h
+	${INC_DIR}/${PROJECT_NAME}/module/add.h
+	${INC_DIR}/${PROJECT_NAME}/module/billow.h
+	${INC_DIR}/${PROJECT_NAME}/module/blend.h
+	${INC_DIR}/${PROJECT_NAME}/module/cache.h
+	${INC_DIR}/${PROJECT_NAME}/module/checkerboard.h
+	${INC_DIR}/${PROJECT_NAME}/module/clamp.h
+	${INC_DIR}/${PROJECT_NAME}/module/const.h
+	${INC_DIR}/${PROJECT_NAME}/module/curve.h
+	${INC_DIR}/${PROJECT_NAME}/module/cylinders.h
+	${INC_DIR}/${PROJECT_NAME}/module/displace.h
+	${INC_DIR}/${PROJECT_NAME}/module/exponent.h
+	${INC_DIR}/${PROJECT_NAME}/module/invert.h
+	${INC_DIR}/${PROJECT_NAME}/module/max.h
+	${INC_DIR}/${PROJECT_NAME}/module/min.h
+	${INC_DIR}/${PROJECT_NAME}/module/module.h
+	${INC_DIR}/${PROJECT_NAME}/module/modulebase.h
+	${INC_DIR}/${PROJECT_NAME}/module/multiply.h
+	${INC_DIR}/${PROJECT_NAME}/module/perlin.h
+	${INC_DIR}/${PROJECT_NAME}/module/power.h
+	${INC_DIR}/${PROJECT_NAME}/module/ridgedmulti.h
+	${INC_DIR}/${PROJECT_NAME}/module/rotatepoint.h
+	${INC_DIR}/${PROJECT_NAME}/module/scalebias.h
+	${INC_DIR}/${PROJECT_NAME}/module/scalepoint.h
+	${INC_DIR}/${PROJECT_NAME}/module/select.h
+	${INC_DIR}/${PROJECT_NAME}/module/spheres.h
+	${INC_DIR}/${PROJECT_NAME}/module/terrace.h
+	${INC_DIR}/${PROJECT_NAME}/module/translatepoint.h
+	${INC_DIR}/${PROJECT_NAME}/module/turbulence.h
+	${INC_DIR}/${PROJECT_NAME}/module/voronoi.h
 	${SRC_DIR}/latlon.cpp
 	${SRC_DIR}/noisegen.cpp
 	${SRC_DIR}/model/cylinder.cpp
@@ -96,7 +96,7 @@ set(
 	${SRC_DIR}/module/voronoi.cpp
 )
 
-include_directories( ${INC_DIR} )
+include_directories( ${INC_DIR}/${PROJECT_NAME} )
 
 add_library( libnoise ${LIB_TYPE} ${SOURCES} )
 

--- a/src/model/cylinder.cpp
+++ b/src/model/cylinder.cpp
@@ -20,8 +20,8 @@
 // off every 'zig'.)
 //
 
-#include "../mathconsts.h"
-#include "cylinder.h"
+#include "mathconsts.h"
+#include "model/cylinder.h"
 
 using namespace noise;
 using namespace noise::model;

--- a/src/model/line.cpp
+++ b/src/model/line.cpp
@@ -17,7 +17,7 @@
 // Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 //
 
-#include "line.h"
+#include "model/line.h"
 
 using namespace noise;
 using namespace noise::model;

--- a/src/model/plane.cpp
+++ b/src/model/plane.cpp
@@ -19,7 +19,7 @@
 // The developer's email is ojacobson@lionsanctuary.net
 //
 
-#include "plane.h"
+#include "model/plane.h"
 
 using namespace noise;
 using namespace noise::model;

--- a/src/model/sphere.cpp
+++ b/src/model/sphere.cpp
@@ -20,8 +20,8 @@
 // off every 'zig'.)
 //
 
-#include "../latlon.h"
-#include "sphere.h"
+#include "latlon.h"
+#include "model/sphere.h"
 
 using namespace noise;
 using namespace noise::model;

--- a/src/module/abs.cpp
+++ b/src/module/abs.cpp
@@ -20,7 +20,7 @@
 // off every 'zig'.)
 //
 
-#include "abs.h"
+#include "module/abs.h"
 
 using namespace noise::module;
 

--- a/src/module/add.cpp
+++ b/src/module/add.cpp
@@ -20,7 +20,7 @@
 // off every 'zig'.)
 //
 
-#include "add.h"
+#include "module/add.h"
 
 using namespace noise::module;
 

--- a/src/module/billow.cpp
+++ b/src/module/billow.cpp
@@ -20,7 +20,7 @@
 // off every 'zig'.)
 //
 
-#include "billow.h"
+#include "module/billow.h"
 
 using namespace noise::module;
 

--- a/src/module/blend.cpp
+++ b/src/module/blend.cpp
@@ -20,8 +20,8 @@
 // off every 'zig'.)
 //
 
-#include "blend.h"
-#include "../interp.h"
+#include "module/blend.h"
+#include "interp.h"
 
 using namespace noise::module;
 

--- a/src/module/cache.cpp
+++ b/src/module/cache.cpp
@@ -20,7 +20,7 @@
 // off every 'zig'.)
 //
 
-#include "cache.h"
+#include "module/cache.h"
 
 using namespace noise::module;
 

--- a/src/module/checkerboard.cpp
+++ b/src/module/checkerboard.cpp
@@ -20,7 +20,7 @@
 // off every 'zig'.)
 //
 
-#include "checkerboard.h"
+#include "module/checkerboard.h"
 
 using namespace noise::module;
 

--- a/src/module/clamp.cpp
+++ b/src/module/clamp.cpp
@@ -20,7 +20,7 @@
 // off every 'zig'.)
 //
 
-#include "clamp.h"
+#include "module/clamp.h"
 
 using namespace noise::module;
 

--- a/src/module/const.cpp
+++ b/src/module/const.cpp
@@ -20,7 +20,7 @@
 // off every 'zig'.)
 //
 
-#include "const.h"
+#include "module/const.h"
 
 using namespace noise::module;
 

--- a/src/module/curve.cpp
+++ b/src/module/curve.cpp
@@ -20,9 +20,9 @@
 // off every 'zig'.)
 //
 
-#include "../interp.h"
-#include "../misc.h"
-#include "curve.h"
+#include "interp.h"
+#include "misc.h"
+#include "module/curve.h"
 
 using namespace noise::module;
 

--- a/src/module/cylinders.cpp
+++ b/src/module/cylinders.cpp
@@ -20,8 +20,8 @@
 // off every 'zig'.)
 //
 
-#include "../misc.h"
-#include "cylinders.h"
+#include "misc.h"
+#include "module/cylinders.h"
 
 using namespace noise::module;
 

--- a/src/module/displace.cpp
+++ b/src/module/displace.cpp
@@ -20,7 +20,7 @@
 // off every 'zig'.)
 //
 
-#include "displace.h"
+#include "module/displace.h"
 
 using namespace noise::module;
 

--- a/src/module/exponent.cpp
+++ b/src/module/exponent.cpp
@@ -20,7 +20,7 @@
 // off every 'zig'.)
 //
 
-#include "exponent.h"
+#include "module/exponent.h"
 
 using namespace noise::module;
 

--- a/src/module/invert.cpp
+++ b/src/module/invert.cpp
@@ -20,7 +20,7 @@
 // off every 'zig'.)
 //
 
-#include "invert.h"
+#include "module/invert.h"
 
 using namespace noise::module;
 

--- a/src/module/max.cpp
+++ b/src/module/max.cpp
@@ -20,8 +20,8 @@
 // off every 'zig'.)
 //
 
-#include "../misc.h"
-#include "max.h"
+#include "misc.h"
+#include "module/max.h"
 
 using namespace noise::module;
 

--- a/src/module/min.cpp
+++ b/src/module/min.cpp
@@ -20,8 +20,8 @@
 // off every 'zig'.)
 //
 
-#include "../misc.h"
-#include "min.h"
+#include "misc.h"
+#include "module/min.h"
 
 using namespace noise::module;
 

--- a/src/module/modulebase.cpp
+++ b/src/module/modulebase.cpp
@@ -20,7 +20,7 @@
 // off every 'zig'.)
 //
 
-#include "modulebase.h"
+#include "module/modulebase.h"
 
 using namespace noise::module;
 

--- a/src/module/multiply.cpp
+++ b/src/module/multiply.cpp
@@ -20,7 +20,7 @@
 // off every 'zig'.)
 //
 
-#include "multiply.h"
+#include "module/multiply.h"
 
 using namespace noise::module;
 

--- a/src/module/perlin.cpp
+++ b/src/module/perlin.cpp
@@ -20,7 +20,7 @@
 // off every 'zig'.)
 //
 
-#include "perlin.h"
+#include "module/perlin.h"
 
 using namespace noise::module;
 

--- a/src/module/power.cpp
+++ b/src/module/power.cpp
@@ -19,7 +19,7 @@
 // The developer's email is angstrom@lionsanctuary.net
 //
 
-#include "power.h"
+#include "module/power.h"
 
 using namespace noise::module;
 

--- a/src/module/ridgedmulti.cpp
+++ b/src/module/ridgedmulti.cpp
@@ -20,7 +20,7 @@
 // off every 'zig'.)
 //
 
-#include "ridgedmulti.h"
+#include "module/ridgedmulti.h"
 
 using namespace noise::module;
 

--- a/src/module/rotatepoint.cpp
+++ b/src/module/rotatepoint.cpp
@@ -20,8 +20,8 @@
 // off every 'zig'.)
 //
 
-#include "../mathconsts.h"
-#include "rotatepoint.h"
+#include "mathconsts.h"
+#include "module/rotatepoint.h"
 
 using namespace noise::module;
 

--- a/src/module/scalebias.cpp
+++ b/src/module/scalebias.cpp
@@ -20,7 +20,7 @@
 // off every 'zig'.)
 //
 
-#include "scalebias.h"
+#include "module/scalebias.h"
 
 using namespace noise::module;
 

--- a/src/module/scalepoint.cpp
+++ b/src/module/scalepoint.cpp
@@ -20,7 +20,7 @@
 // off every 'zig'.)
 //
 
-#include "scalepoint.h"
+#include "module/scalepoint.h"
 
 using namespace noise::module;
 

--- a/src/module/select.cpp
+++ b/src/module/select.cpp
@@ -20,8 +20,8 @@
 // off every 'zig'.)
 //
 
-#include "../interp.h"
-#include "select.h"
+#include "interp.h"
+#include "module/select.h"
 
 using namespace noise::module;
 

--- a/src/module/spheres.cpp
+++ b/src/module/spheres.cpp
@@ -20,8 +20,8 @@
 // off every 'zig'.)
 //
 
-#include "../misc.h"
-#include "spheres.h"
+#include "misc.h"
+#include "module/spheres.h"
 
 using namespace noise::module;
 

--- a/src/module/terrace.cpp
+++ b/src/module/terrace.cpp
@@ -20,9 +20,9 @@
 // off every 'zig'.)
 //
 
-#include "../interp.h"
-#include "../misc.h"
-#include "terrace.h"
+#include "interp.h"
+#include "misc.h"
+#include "module/terrace.h"
 
 using namespace noise::module;
 

--- a/src/module/translatepoint.cpp
+++ b/src/module/translatepoint.cpp
@@ -20,7 +20,7 @@
 // off every 'zig'.)
 //
 
-#include "translatepoint.h"
+#include "module/translatepoint.h"
 
 using namespace noise::module;
 

--- a/src/module/turbulence.cpp
+++ b/src/module/turbulence.cpp
@@ -20,7 +20,7 @@
 // off every 'zig'.)
 //
 
-#include "turbulence.h"
+#include "module/turbulence.h"
 
 using namespace noise::module;
 

--- a/src/module/voronoi.cpp
+++ b/src/module/voronoi.cpp
@@ -20,8 +20,8 @@
 // off every 'zig'.)
 //
 
-#include "../mathconsts.h"
-#include "voronoi.h"
+#include "mathconsts.h"
+#include "module/voronoi.h"
 
 using namespace noise::module;
 


### PR DESCRIPTION
When the `src/` and `include/` separation was made, all the include paths in the source `.cpp` files were changed. In this fork, I fixed the include paths in the `CMakeLists.txt`, and made the file a bit more standard, and I also fixed the include paths in all of the source files that needed fixing.
